### PR TITLE
Fix the check of `is_default` account flag

### DIFF
--- a/example_base.rb
+++ b/example_base.rb
@@ -64,10 +64,6 @@ class ExampleBase
       raise "The user does not have access to account #{target}"
     end
 
-    accounts.each do |acct|
-      if acct.is_default
-        return acct
-      end
-    end
+    accounts.find { |acct| acct.is_default == 'true' }
   end
 end


### PR DESCRIPTION
The `is_default` flag contains a string value. So if the result of `acct.is_default` is `"false"` it will be regarded as truly value, cause any value of type `String` is being typecasted to `True` in a conditional statement.